### PR TITLE
merge common into lib

### DIFF
--- a/scripts/load.sh
+++ b/scripts/load.sh
@@ -1,4 +1,6 @@
 rmmod xclmgmt
 modprobe fpga_mgr
+modprobe fpga_region
+modprobe fpga_bridge
 insmod ./lib/xrt-lib.ko
 insmod ./mgmt/xmgmt.ko

--- a/src/drivers/fpga/xrt/include/xrt-root.h
+++ b/src/drivers/fpga/xrt/include/xrt-root.h
@@ -14,13 +14,21 @@
 
 struct xroot;
 
-int xroot_probe(struct pci_dev *pdev, struct xroot **root);
+/*
+ * Defines physical function (MPF / UPF) specific operations
+ * needed in common root driver.
+ */
+struct xroot_pf_cb {
+	void (*xpc_hot_reset)(struct pci_dev *pdev);
+};
+
+int xroot_probe(struct pci_dev *pdev, struct xroot_pf_cb *cb,
+	struct xroot **root);
 void xroot_remove(struct xroot *root);
 bool xroot_wait_for_bringup(struct xroot *root);
 int xroot_add_vsec_node(struct xroot *root, char *dtb);
 int xroot_create_partition(struct xroot *xr, char *dtb);
 int xroot_add_simple_node(struct xroot *root, char *dtb, const char *endpoint);
-void xroot_hot_reset(struct pci_dev *pdev);
 void xroot_broadcast(struct xroot *root, enum xrt_events evt);
 
 #endif	/* _XRT_ROOT_H_ */

--- a/src/drivers/fpga/xrt/include/xrt-xclbin.h
+++ b/src/drivers/fpga/xrt/include/xrt-xclbin.h
@@ -43,6 +43,6 @@ int xrt_xclbin_get_metadata(struct device *dev, const struct axlf *xclbin, char 
 int xrt_xclbin_parse_header(const unsigned char *data,
 	unsigned int size, struct XHwIcap_Bit_Header *header);
 void xrt_xclbin_free_header(struct XHwIcap_Bit_Header *header);
-const char *clock_type2epname(enum CLOCK_TYPE type);
+const char *xrt_clock_type2epname(enum CLOCK_TYPE type);
 
 #endif /* _XRT_XCLBIN_H */

--- a/src/drivers/fpga/xrt/lib/Makefile
+++ b/src/drivers/fpga/xrt/lib/Makefile
@@ -13,7 +13,7 @@ xrt-lib-y := 				\
 	xrt-subdev.o			\
 	xrt-cdev.o			\
 	../common/xrt-metadata.o	\
-	subdevs/xrt-partition.o	\
+	xrt-partition.o			\
 	subdevs/xrt-test.o		\
 	subdevs/xrt-vsec.o		\
 	subdevs/xrt-vsec-golden.o	\

--- a/src/drivers/fpga/xrt/lib/Makefile
+++ b/src/drivers/fpga/xrt/lib/Makefile
@@ -10,9 +10,11 @@ obj-m   += xrt-lib.o
 fdtdir := ../../../../lib
 xrt-lib-y := 				\
 	xrt-main.o			\
+	xrt-root.o			\
+	xrt-xclbin.o			\
+	xrt-metadata.o			\
 	xrt-subdev.o			\
 	xrt-cdev.o			\
-	../common/xrt-metadata.o	\
 	xrt-partition.o			\
 	subdevs/xrt-test.o		\
 	subdevs/xrt-vsec.o		\
@@ -51,7 +53,7 @@ KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 
 PWD	:= $(shell pwd)
 ROOT	:= $(dir $(M))/../../../
-XILINXINCLUDE := -I$(ROOT)/drivers/fpga/xrt/include -I$(ROOT)/include/uapi -I$(ROOT)/scripts/dtc/libfdt -I$(ROOT)/drivers/fpga/xrt/common
+XILINXINCLUDE := -I$(ROOT)/drivers/fpga/xrt/include -I$(ROOT)/include/uapi -I$(ROOT)/scripts/dtc/libfdt
 
 ccflags-y += $(XILINXINCLUDE)
 ifeq ($(DEBUG),1)

--- a/src/drivers/fpga/xrt/lib/xrt-metadata.c
+++ b/src/drivers/fpga/xrt/lib/xrt-metadata.c
@@ -36,6 +36,7 @@ long xrt_md_size(struct device *dev, const char *blob)
 
 	return (len > MAX_BLOB_SIZE) ? -EINVAL : len;
 }
+EXPORT_SYMBOL_GPL(xrt_md_size);
 
 int xrt_md_create(struct device *dev, char **blob)
 {
@@ -72,6 +73,7 @@ failed:
 
 	return ret;
 }
+EXPORT_SYMBOL_GPL(xrt_md_create);
 
 int xrt_md_add_node(struct device *dev, char *blob, int parent_offset,
 	const char *ep_name)
@@ -227,6 +229,7 @@ int xrt_md_get_epname_pointer(struct device *dev, const char *blob,
 
 	return ret;
 }
+EXPORT_SYMBOL_GPL(xrt_md_get_epname_pointer);
 
 int xrt_md_get_prop(struct device *dev, const char *blob, const char *ep_name,
 	const char *regmap_name, const char *prop, const void **val, int *size)
@@ -262,6 +265,7 @@ int xrt_md_get_prop(struct device *dev, const char *blob, const char *ep_name,
 
 	return 0;
 }
+EXPORT_SYMBOL_GPL(xrt_md_get_prop);
 
 static int xrt_md_setprop(struct device *dev, char *blob, int offset,
 	 const char *prop, const void *val, int size)
@@ -304,6 +308,7 @@ int xrt_md_set_prop(struct device *dev, char *blob,
 
 	return ret;
 }
+EXPORT_SYMBOL_GPL(xrt_md_set_prop);
 
 int xrt_md_copy_endpoint(struct device *dev, char *blob, const char *src_blob,
 	const char *ep_name, const char *regmap_name, const char *new_ep_name)
@@ -333,6 +338,7 @@ int xrt_md_copy_endpoint(struct device *dev, char *blob, const char *src_blob,
 
 	return ret;
 }
+EXPORT_SYMBOL_GPL(xrt_md_copy_endpoint);
 
 int xrt_md_copy_all_eps(struct device *dev, char *blob, const char *src_blob)
 {
@@ -459,6 +465,7 @@ int xrt_md_get_next_endpoint(struct device *dev, const char *blob,
 
 	return 0;
 }
+EXPORT_SYMBOL_GPL(xrt_md_get_next_endpoint);
 
 int xrt_md_get_compatible_epname(struct device *dev, const char *blob,
 	const char *regmap_name, const char **ep_name)
@@ -501,6 +508,7 @@ int xrt_md_uuid_strtoid(struct device *dev, const char *uuidstr, uuid_t *p_uuid)
 
 	return 0;
 }
+EXPORT_SYMBOL_GPL(xrt_md_uuid_strtoid);
 
 void xrt_md_pack(struct device *dev, char *blob)
 {
@@ -510,6 +518,7 @@ void xrt_md_pack(struct device *dev, char *blob)
 	if (ret)
 		md_err(dev, "pack failed %d", ret);
 }
+EXPORT_SYMBOL_GPL(xrt_md_pack);
 
 int xrt_md_get_intf_uuids(struct device *dev, const char *blob,
 	u32 *num_uuids, uuid_t *intf_uuids)
@@ -545,6 +554,7 @@ int xrt_md_get_intf_uuids(struct device *dev, const char *blob,
 
 	return 0;
 }
+EXPORT_SYMBOL_GPL(xrt_md_get_intf_uuids);
 
 int xrt_md_check_uuids(struct device *dev, const char *blob, char *subset_blob)
 {

--- a/src/drivers/fpga/xrt/lib/xrt-partition.c
+++ b/src/drivers/fpga/xrt/lib/xrt-partition.c
@@ -14,7 +14,7 @@
 #include "parent.h"
 #include "partition.h"
 #include "metadata.h"
-#include "../xrt-main.h"
+#include "xrt-main.h"
 
 #define	XRT_PART "xrt_partition"
 

--- a/src/drivers/fpga/xrt/lib/xrt-xclbin.c
+++ b/src/drivers/fpga/xrt/lib/xrt-xclbin.c
@@ -130,6 +130,7 @@ int xrt_xclbin_get_section(const struct axlf *buf,
 
 	return 0;
 }
+EXPORT_SYMBOL_GPL(xrt_xclbin_get_section);
 
 /* parse bitstream header */
 int xrt_xclbin_parse_header(const unsigned char *data,
@@ -263,6 +264,7 @@ int xrt_xclbin_parse_header(const unsigned char *data,
 
 	return 0;
 }
+EXPORT_SYMBOL_GPL(xrt_xclbin_parse_header);
 
 void xrt_xclbin_free_header(struct XHwIcap_Bit_Header *header)
 {
@@ -294,7 +296,7 @@ struct xrt_clock_desc {
 	},
 };
 
-const char *clock_type2epname(enum CLOCK_TYPE type)
+const char *xrt_clock_type2epname(enum CLOCK_TYPE type)
 {
 	int i;
 
@@ -304,6 +306,7 @@ const char *clock_type2epname(enum CLOCK_TYPE type)
 	}
 	return NULL;
 }
+EXPORT_SYMBOL_GPL(xrt_clock_type2epname);
 
 static const char *clock_type2clkfreq_name(u32 type)
 {
@@ -330,7 +333,7 @@ static int xrt_xclbin_add_clock_metadata(struct device *dev,
 
 	for (i = 0; i < clock_topo->m_count; i++) {
 		u8 type = clock_topo->m_clock_freq[i].m_type;
-		const char *ep_name = clock_type2epname(type);
+		const char *ep_name = xrt_clock_type2epname(type);
 		const char *counter_name = clock_type2clkfreq_name(type);
 
 		if (!ep_name || !counter_name)
@@ -385,3 +388,4 @@ done:
 	vfree(md);
 	return rc;
 }
+EXPORT_SYMBOL_GPL(xrt_xclbin_get_metadata);

--- a/src/drivers/fpga/xrt/mgmt/Makefile
+++ b/src/drivers/fpga/xrt/mgmt/Makefile
@@ -7,16 +7,12 @@
 
 obj-m	+= xmgmt.o
 
-commondir := ../common
 fdtdir := ../../../../lib
 xmgmt-y := xmgmt-root.o				\
 	   xmgmt-main.o				\
 	   xmgmt-fmgr-drv.o      		\
 	   xmgmt-main-region.o			\
 	   xmgmt-main-mailbox.o			\
-	   $(commondir)/xrt-root.o		\
-	   $(commondir)/xrt-metadata.o		\
-	   $(commondir)/xrt-xclbin.o		\
 	   $(fdtdir)/fdt.o			\
 	   $(fdtdir)/fdt_addresses.o		\
 	   $(fdtdir)/fdt_empty_tree.o		\
@@ -32,7 +28,7 @@ KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 
 PWD	:= $(shell pwd)
 ROOT	:= $(dir $(M))/../../../
-XILINXINCLUDE := -I$(ROOT)/drivers/fpga/xrt/include -I$(ROOT)/include/uapi -I$(ROOT)/scripts/dtc/libfdt -I$(ROOT)/drivers/fpga/xrt/common
+XILINXINCLUDE := -I$(ROOT)/drivers/fpga/xrt/include -I$(ROOT)/include/uapi -I$(ROOT)/scripts/dtc/libfdt
 
 ccflags-y += $(XILINXINCLUDE)
 ifeq ($(DEBUG),1)
@@ -45,4 +41,4 @@ all:
 clean:
 	rm -rf *.o *.o.d *~ core .depend .*.cmd *.ko *.ko.unsigned *.mod.c \
 	.tmp_versions *.symvers modules.order *.mod .cache.mk \
-	$(fdtdir)/*.o $(commondir)/*.o $(commondir)/*.o.cmd
+	$(fdtdir)/*.o

--- a/src/drivers/fpga/xrt/mgmt/xmgmt-main-mailbox.c
+++ b/src/drivers/fpga/xrt/mgmt/xmgmt-main-mailbox.c
@@ -398,7 +398,8 @@ static int xmgmt_mailbox_get_freq(struct xmgmt_mailbox *xmbx,
 {
 	struct platform_device *pdev = xmbx->pdev;
 	const char *clkname =
-		clock_type2epname(type) ? clock_type2epname(type) : "UNKNOWN";
+		xrt_clock_type2epname(type) ?
+		xrt_clock_type2epname(type) : "UNKNOWN";
 	struct platform_device *clkpdev =
 		xrt_subdev_get_leaf_by_epname(pdev, clkname);
 	int rc;

--- a/src/drivers/fpga/xrt/mgmt/xmgmt-root.c
+++ b/src/drivers/fpga/xrt/mgmt/xmgmt-root.c
@@ -153,7 +153,7 @@ static void xmgmt_pci_restore_config_all(struct xmgmt *xm)
 	bus_for_each_dev(&pci_bus_type, NULL, xm, xmgmt_match_slot_and_restore);
 }
 
-void xroot_hot_reset(struct pci_dev *pdev)
+void xmgmt_root_hot_reset(struct pci_dev *pdev)
 {
 	struct xmgmt *xm = pci_get_drvdata(pdev);
 	struct pci_bus *bus;
@@ -268,6 +268,10 @@ static struct attribute_group xmgmt_root_attr_group = {
 	.attrs = xmgmt_root_attrs,
 };
 
+static struct xroot_pf_cb xmgmt_xroot_pf_cb = {
+	.xpc_hot_reset = xmgmt_root_hot_reset,
+};
+
 static int xmgmt_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 {
 	int ret;
@@ -284,7 +288,7 @@ static int xmgmt_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	if (ret)
 		goto failed;
 
-	ret = xroot_probe(pdev, &xm->root);
+	ret = xroot_probe(pdev, &xmgmt_xroot_pf_cb, &xm->root);
 	if (ret)
 		goto failed;
 


### PR DESCRIPTION
This pull request merges C files under common directory into lib ko, which requires a lot more exported symbols since xmgmt needs to call them.
The xrt-root lives in xrt-lib.ko now, but it needs to call physical function specific hot reset routine in xmgmt. I changed the code to have xmgmt to register the function with xrt-root now for this.
Let me know what you think...