### PR TITLE
refactor include header files

### DIFF
--- a/src/drivers/fpga/xrt/include/events.h
+++ b/src/drivers/fpga/xrt/include/events.h
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2020 Xilinx, Inc.
+ *
+ * Authors:
+ *	Cheng Zhen <maxz@xilinx.com>
+ */
+
+#ifndef	_XRT_EVENTS_H_
+#define	_XRT_EVENTS_H_
+
+#include <linux/platform_device.h>
+#include "subdev_id.h"
+
+/*
+ * Event notification.
+ */
+enum xrt_events {
+	XRT_EVENT_TEST = 0, // for testing
+	/*
+	 * Events related to specific subdev
+	 * Callback arg: struct xrt_event_arg_subdev
+	 */
+	XRT_EVENT_POST_CREATION,
+	XRT_EVENT_PRE_REMOVAL,
+	/*
+	 * Events related to change of the whole board
+	 * Callback arg: <none>
+	 */
+	XRT_EVENT_PRE_HOT_RESET,
+	XRT_EVENT_POST_HOT_RESET,
+	XRT_EVENT_PRE_GATE_CLOSE,
+	XRT_EVENT_POST_GATE_OPEN,
+	XRT_EVENT_POST_ATTACH,
+	XRT_EVENT_PRE_DETACH,
+};
+
+typedef int (*xrt_event_cb_t)(struct platform_device *pdev,
+	enum xrt_events evt, void *arg);
+typedef void (*xrt_async_broadcast_event_cb_t)(struct platform_device *pdev,
+	enum xrt_events evt, void *arg, bool success);
+
+struct xrt_event_arg_subdev {
+	enum xrt_subdev_id xevt_subdev_id;
+	int xevt_subdev_instance;
+};
+
+/*
+ * Flags in return value from event callback.
+ */
+/* Done with event handling, continue waiting for the next one */
+#define	XRT_EVENT_CB_CONTINUE	0x0
+/* Done with event handling, stop waiting for the next one */
+#define	XRT_EVENT_CB_STOP	0x1
+/* Error processing event */
+#define	XRT_EVENT_CB_ERR	0x2
+
+#endif	/* _XRT_EVENTS_H_ */

--- a/src/drivers/fpga/xrt/include/parent.h
+++ b/src/drivers/fpga/xrt/include/parent.h
@@ -9,7 +9,7 @@
 #ifndef	_XRT_PARENT_H_
 #define	_XRT_PARENT_H_
 
-#include "subdev.h"
+#include "leaf.h"
 #include "partition.h"
 
 /*

--- a/src/drivers/fpga/xrt/include/partition.h
+++ b/src/drivers/fpga/xrt/include/partition.h
@@ -9,7 +9,7 @@
 #ifndef	_XRT_PARTITION_H_
 #define	_XRT_PARTITION_H_
 
-#include "subdev.h"
+#include "leaf.h"
 
 /*
  * Partition driver IOCTL calls.

--- a/src/drivers/fpga/xrt/include/root.h
+++ b/src/drivers/fpga/xrt/include/root.h
@@ -10,7 +10,7 @@
 #define	_XRT_ROOT_H_
 
 #include <linux/pci.h>
-#include "subdev.h"
+#include "events.h"
 
 struct xroot;
 

--- a/src/drivers/fpga/xrt/include/subdev/axigate.h
+++ b/src/drivers/fpga/xrt/include/subdev/axigate.h
@@ -10,7 +10,7 @@
 #define	_XRT_AXIGATE_H_
 
 
-#include "subdev.h"
+#include "leaf.h"
 #include "metadata.h"
 
 /*

--- a/src/drivers/fpga/xrt/include/subdev/calib.h
+++ b/src/drivers/fpga/xrt/include/subdev/calib.h
@@ -9,7 +9,7 @@
 #ifndef	_XRT_CALIB_H_
 #define	_XRT_CALIB_H_
 
-#include "subdev.h"
+#include "leaf.h"
 #include <linux/xrt/xclbin.h>
 
 /*

--- a/src/drivers/fpga/xrt/include/subdev/clkfreq.h
+++ b/src/drivers/fpga/xrt/include/subdev/clkfreq.h
@@ -9,7 +9,7 @@
 #ifndef	_XRT_CLKFREQ_H_
 #define	_XRT_CLKFREQ_H_
 
-#include "subdev.h"
+#include "leaf.h"
 
 /*
  * CLKFREQ driver IOCTL calls.

--- a/src/drivers/fpga/xrt/include/subdev/clock.h
+++ b/src/drivers/fpga/xrt/include/subdev/clock.h
@@ -9,7 +9,7 @@
 #ifndef	_XRT_CLOCK_H_
 #define	_XRT_CLOCK_H_
 
-#include "subdev.h"
+#include "leaf.h"
 #include <linux/xrt/xclbin.h>
 
 /*

--- a/src/drivers/fpga/xrt/include/subdev/cmc.h
+++ b/src/drivers/fpga/xrt/include/subdev/cmc.h
@@ -9,7 +9,7 @@
 #ifndef	_XRT_CMC_H_
 #define	_XRT_CMC_H_
 
-#include "subdev.h"
+#include "leaf.h"
 #include <linux/xrt/xclbin.h>
 
 /*

--- a/src/drivers/fpga/xrt/include/subdev/ddr-srsr.h
+++ b/src/drivers/fpga/xrt/include/subdev/ddr-srsr.h
@@ -9,7 +9,7 @@
 #ifndef _XRT_DDR_SRSR_H_
 #define _XRT_DDR_SRSR_H_
 
-#include "subdev.h"
+#include "leaf.h"
 
 /*
  * ddr-srsr driver IOCTL calls.

--- a/src/drivers/fpga/xrt/include/subdev/flash.h
+++ b/src/drivers/fpga/xrt/include/subdev/flash.h
@@ -9,7 +9,7 @@
 #ifndef	_XRT_FLASH_H_
 #define	_XRT_FLASH_H_
 
-#include "subdev.h"
+#include "leaf.h"
 
 /*
  * Flash controller driver IOCTL calls.

--- a/src/drivers/fpga/xrt/include/subdev/gpio.h
+++ b/src/drivers/fpga/xrt/include/subdev/gpio.h
@@ -9,7 +9,7 @@
 #ifndef	_XRT_GPIO_H_
 #define	_XRT_GPIO_H_
 
-#include "subdev.h"
+#include "leaf.h"
 
 /*
  * GPIO driver IOCTL calls.

--- a/src/drivers/fpga/xrt/include/subdev/icap.h
+++ b/src/drivers/fpga/xrt/include/subdev/icap.h
@@ -9,7 +9,7 @@
 #ifndef	_XRT_ICAP_H_
 #define	_XRT_ICAP_H_
 
-#include "subdev.h"
+#include "leaf.h"
 
 /*
  * ICAP driver IOCTL calls.

--- a/src/drivers/fpga/xrt/include/subdev/ucs.h
+++ b/src/drivers/fpga/xrt/include/subdev/ucs.h
@@ -9,7 +9,7 @@
 #ifndef	_XRT_UCS_H_
 #define	_XRT_UCS_H_
 
-#include "subdev.h"
+#include "leaf.h"
 
 /*
  * UCS driver IOCTL calls.

--- a/src/drivers/fpga/xrt/include/subdev_id.h
+++ b/src/drivers/fpga/xrt/include/subdev_id.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2020 Xilinx, Inc.
+ *
+ * Authors:
+ *	Cheng Zhen <maxz@xilinx.com>
+ */
+
+#ifndef	_XRT_SUBDEV_ID_H_
+#define	_XRT_SUBDEV_ID_H_
+
+/*
+ * Every subdev driver should have an ID for others to refer to it.
+ * There can be unlimited number of instances of a subdev driver. A
+ * <subdev_id, subdev_instance> tuple should be a unique identification of
+ * a specific instance of a subdev driver.
+ * NOTE: PLEASE do not change the order of IDs. Sub devices in the same
+ * partition are initialized by this order.
+ */
+enum xrt_subdev_id {
+	XRT_SUBDEV_PART = 0,
+	XRT_SUBDEV_VSEC,
+	XRT_SUBDEV_VSEC_GOLDEN,
+	XRT_SUBDEV_GPIO,
+	XRT_SUBDEV_AXIGATE,
+	XRT_SUBDEV_ICAP,
+	XRT_SUBDEV_TEST,
+	XRT_SUBDEV_MGMT_MAIN,
+	XRT_SUBDEV_QSPI,
+	XRT_SUBDEV_MAILBOX,
+	XRT_SUBDEV_CMC,
+	XRT_SUBDEV_CALIB,
+	XRT_SUBDEV_CLKFREQ,
+	XRT_SUBDEV_CLOCK,
+	XRT_SUBDEV_SRSR,
+	XRT_SUBDEV_UCS,
+	XRT_SUBDEV_NUM,
+};
+
+#endif	/* _XRT_SUBDEV_ID_H_ */

--- a/src/drivers/fpga/xrt/lib/cdev.c
+++ b/src/drivers/fpga/xrt/lib/cdev.c
@@ -8,7 +8,7 @@
  *	Cheng Zhen <maxz@xilinx.com>
  */
 
-#include "subdev.h"
+#include "leaf.h"
 
 extern struct class *xrt_class;
 
@@ -20,7 +20,7 @@ extern struct class *xrt_class;
 #define	CDEV_NAME(sysdev)	(strchr((sysdev)->kobj.name, '!') + 1)
 
 /* Allow it to be accessed from cdev. */
-static void xrt_devnode_allowed(struct platform_device *pdev)
+static void xleaf_devnode_allowed(struct platform_device *pdev)
 {
 	struct xrt_subdev_platdata *pdata = DEV_PDATA(pdev);
 
@@ -31,7 +31,7 @@ static void xrt_devnode_allowed(struct platform_device *pdev)
 }
 
 /* Turn off access from cdev and wait for all existing user to go away. */
-static int xrt_devnode_disallowed(struct platform_device *pdev)
+static int xleaf_devnode_disallowed(struct platform_device *pdev)
 {
 	int ret = 0;
 	struct xrt_subdev_platdata *pdata = DEV_PDATA(pdev);
@@ -64,7 +64,7 @@ static int xrt_devnode_disallowed(struct platform_device *pdev)
 }
 
 static struct platform_device *
-__xrt_devnode_open(struct inode *inode, bool excl)
+__xleaf_devnode_open(struct inode *inode, bool excl)
 {
 	struct xrt_subdev_platdata *pdata = INODE2PDATA(inode);
 	struct platform_device *pdev = INODE2PDEV(inode);
@@ -97,19 +97,19 @@ __xrt_devnode_open(struct inode *inode, bool excl)
 }
 
 struct platform_device *
-xrt_devnode_open_excl(struct inode *inode)
+xleaf_devnode_open_excl(struct inode *inode)
 {
-	return __xrt_devnode_open(inode, true);
+	return __xleaf_devnode_open(inode, true);
 }
 
 struct platform_device *
-xrt_devnode_open(struct inode *inode)
+xleaf_devnode_open(struct inode *inode)
 {
-	return __xrt_devnode_open(inode, false);
+	return __xleaf_devnode_open(inode, false);
 }
-EXPORT_SYMBOL_GPL(xrt_devnode_open);
+EXPORT_SYMBOL_GPL(xleaf_devnode_open);
 
-void xrt_devnode_close(struct inode *inode)
+void xleaf_devnode_close(struct inode *inode)
 {
 	struct xrt_subdev_platdata *pdata = INODE2PDATA(inode);
 	struct platform_device *pdev = INODE2PDEV(inode);
@@ -135,7 +135,7 @@ void xrt_devnode_close(struct inode *inode)
 	if (notify)
 		complete(&pdata->xsp_devnode_comp);
 }
-EXPORT_SYMBOL_GPL(xrt_devnode_close);
+EXPORT_SYMBOL_GPL(xleaf_devnode_close);
 
 static inline enum xrt_subdev_file_mode
 devnode_mode(struct xrt_subdev_drvdata *drvdata)
@@ -143,7 +143,7 @@ devnode_mode(struct xrt_subdev_drvdata *drvdata)
 	return drvdata->xsd_file_ops.xsf_mode;
 }
 
-int xrt_devnode_create(struct platform_device *pdev, const char *file_name,
+int xleaf_devnode_create(struct platform_device *pdev, const char *file_name,
 	const char *inst_name)
 {
 	struct xrt_subdev_drvdata *drvdata = DEV_DRVDATA(pdev);
@@ -199,7 +199,7 @@ int xrt_devnode_create(struct platform_device *pdev, const char *file_name,
 	}
 	pdata->xsp_sysdev = sysdev;
 
-	xrt_devnode_allowed(pdev);
+	xleaf_devnode_allowed(pdev);
 
 	xrt_info(pdev, "created (%d, %d): /dev/%s",
 		MAJOR(cdevp->dev), pdev->id, fname);
@@ -212,7 +212,7 @@ failed:
 	return ret;
 }
 
-int xrt_devnode_destroy(struct platform_device *pdev)
+int xleaf_devnode_destroy(struct platform_device *pdev)
 {
 	struct xrt_subdev_platdata *pdata = DEV_PDATA(pdev);
 	struct cdev *cdevp = &pdata->xsp_cdev;
@@ -221,7 +221,7 @@ int xrt_devnode_destroy(struct platform_device *pdev)
 
 	BUG_ON(!cdevp->owner);
 
-	rc = xrt_devnode_disallowed(pdev);
+	rc = xleaf_devnode_disallowed(pdev);
 	if (rc)
 		return rc;
 

--- a/src/drivers/fpga/xrt/lib/main.c
+++ b/src/drivers/fpga/xrt/lib/main.c
@@ -7,7 +7,8 @@
  */
 
 #include <linux/module.h>
-#include "subdev.h"
+#include "leaf.h"
+#include "root.h"
 #include "main.h"
 
 #define	XRT_IPLIB_MODULE_NAME		"xrt-lib"
@@ -103,7 +104,7 @@ static int xrt_drv_register_driver(enum xrt_subdev_id id)
 
 	if (drvdata) {
 		/* Initialize dev_t for char dev node. */
-		if (xrt_devnode_enabled(drvdata)) {
+		if (xleaf_devnode_enabled(drvdata)) {
 			rc = alloc_chrdev_region(
 				&drvdata->xsd_file_ops.xsf_dev_t, 0,
 				XRT_MAX_DEVICE_NODES, drvname);
@@ -156,7 +157,7 @@ static void xrt_drv_unregister_driver(enum xrt_subdev_id id)
 	pr_info("unregistered %s subdev driver\n", drvname);
 }
 
-int xrt_subdev_register_external_driver(enum xrt_subdev_id id,
+int xleaf_register_external_driver(enum xrt_subdev_id id,
 	struct platform_driver *drv, struct xrt_subdev_endpoints *eps)
 {
 	int i;
@@ -182,9 +183,9 @@ int xrt_subdev_register_external_driver(enum xrt_subdev_id id,
 	mutex_unlock(&xrt_class_lock);
 	return result;
 }
-EXPORT_SYMBOL_GPL(xrt_subdev_register_external_driver);
+EXPORT_SYMBOL_GPL(xleaf_register_external_driver);
 
-void xrt_subdev_unregister_external_driver(enum xrt_subdev_id id)
+void xleaf_unregister_external_driver(enum xrt_subdev_id id)
 {
 	int i;
 
@@ -201,7 +202,7 @@ void xrt_subdev_unregister_external_driver(enum xrt_subdev_id id)
 	}
 	mutex_unlock(&xrt_class_lock);
 }
-EXPORT_SYMBOL_GPL(xrt_subdev_unregister_external_driver);
+EXPORT_SYMBOL_GPL(xleaf_unregister_external_driver);
 
 static __init int xrt_drv_register_drivers(void)
 {

--- a/src/drivers/fpga/xrt/lib/partition.c
+++ b/src/drivers/fpga/xrt/lib/partition.c
@@ -10,7 +10,8 @@
 
 #include <linux/mod_devicetable.h>
 #include <linux/platform_device.h>
-#include "subdev.h"
+#include "leaf.h"
+#include "subdev_pool.h"
 #include "parent.h"
 #include "partition.h"
 #include "metadata.h"

--- a/src/drivers/fpga/xrt/lib/root.c
+++ b/src/drivers/fpga/xrt/lib/root.c
@@ -10,7 +10,8 @@
 #include <linux/module.h>
 #include <linux/pci.h>
 #include <linux/hwmon.h>
-#include "subdev.h"
+#include "leaf.h"
+#include "subdev_pool.h"
 #include "parent.h"
 #include "partition.h"
 #include "root.h"
@@ -130,7 +131,7 @@ xroot_partition_trigger_evt(struct xroot *xr, struct xroot_event_cb *cb,
 			return rc;
 	}
 
-	return xrt_subdev_ioctl(part, XRT_PARTITION_EVENT, &e);
+	return xleaf_ioctl(part, XRT_PARTITION_EVENT, &e);
 }
 
 static void
@@ -196,7 +197,7 @@ static int xroot_destroy_single_partition(struct xroot *xr, int instance)
 	xroot_event_partition(xr, instance, XRT_EVENT_PRE_REMOVAL);
 
 	/* Now tear down all children in this partition. */
-	ret = xrt_subdev_ioctl(pdev, XRT_PARTITION_FINI_CHILDREN, NULL);
+	ret = xleaf_ioctl(pdev, XRT_PARTITION_FINI_CHILDREN, NULL);
 	(void) xroot_put_partition(xr, pdev);
 	if (!ret) {
 		ret = xrt_subdev_pool_del(&xr->parts.pool,
@@ -435,7 +436,7 @@ static int xroot_get_leaf(struct xroot *xr,
 
 	while (rc && xroot_get_partition(xr, XROOT_PART_LAST,
 		&part) != -ENOENT) {
-		rc = xrt_subdev_ioctl(part, XRT_PARTITION_GET_LEAF, arg);
+		rc = xleaf_ioctl(part, XRT_PARTITION_GET_LEAF, arg);
 		xroot_put_partition(xr, part);
 	}
 	return rc;
@@ -449,7 +450,7 @@ static int xroot_put_leaf(struct xroot *xr,
 
 	while (rc && xroot_get_partition(xr, XROOT_PART_LAST,
 		&part) != -ENOENT) {
-		rc = xrt_subdev_ioctl(part, XRT_PARTITION_PUT_LEAF, arg);
+		rc = xleaf_ioctl(part, XRT_PARTITION_PUT_LEAF, arg);
 		xroot_put_partition(xr, part);
 	}
 	return rc;
@@ -576,7 +577,7 @@ static void xroot_bringup_partition_work(struct work_struct *work)
 		int r, i;
 
 		i = pdev->id;
-		r = xrt_subdev_ioctl(pdev, XRT_PARTITION_INIT_CHILDREN, NULL);
+		r = xleaf_ioctl(pdev, XRT_PARTITION_INIT_CHILDREN, NULL);
 		(void) xroot_put_partition(xr, pdev);
 		if (r == -EEXIST)
 			continue; /* Already brough up, nothing to do. */

--- a/src/drivers/fpga/xrt/lib/subdev_pool.h
+++ b/src/drivers/fpga/xrt/lib/subdev_pool.h
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2020 Xilinx, Inc.
+ *
+ * Authors:
+ *	Cheng Zhen <maxz@xilinx.com>
+ */
+
+#ifndef	_XRT_SUBDEV_POOL_H_
+#define	_XRT_SUBDEV_POOL_H_
+
+#include "leaf.h"
+
+/*
+ * It manages a list of xrt_subdevs for root and partition drivers.
+ */
+struct xrt_subdev_pool {
+	struct list_head xpool_dev_list;
+	struct device *xpool_owner;
+	struct mutex xpool_lock;
+	bool xpool_closing;
+};
+
+/*
+ * Subdev pool API for root and partition drivers only.
+ */
+extern void xrt_subdev_pool_init(struct device *dev,
+	struct xrt_subdev_pool *spool);
+extern int xrt_subdev_pool_fini(struct xrt_subdev_pool *spool);
+extern int xrt_subdev_pool_get(struct xrt_subdev_pool *spool,
+	xrt_subdev_match_t match, void *arg, struct device *holder_dev,
+	struct platform_device **pdevp);
+extern int xrt_subdev_pool_put(struct xrt_subdev_pool *spool,
+	struct platform_device *pdev, struct device *holder_dev);
+extern int xrt_subdev_pool_add(struct xrt_subdev_pool *spool,
+	enum xrt_subdev_id id, xrt_subdev_parent_cb_t pcb,
+	void *pcb_arg, char *dtb);
+extern int xrt_subdev_pool_del(struct xrt_subdev_pool *spool,
+	enum xrt_subdev_id id, int instance);
+extern int xrt_subdev_pool_event(struct xrt_subdev_pool *spool,
+	struct platform_device *pdev, xrt_subdev_match_t match, void *arg,
+	xrt_event_cb_t xevt_cb, enum xrt_events evt);
+extern ssize_t xrt_subdev_pool_get_holders(struct xrt_subdev_pool *spool,
+	struct platform_device *pdev, char *buf, size_t len);
+
+#endif	/* _XRT_SUBDEV_POOL_H_ */

--- a/src/drivers/fpga/xrt/lib/subdevs/calib.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/calib.c
@@ -72,7 +72,7 @@ static int calib_srsr(struct calib *calib, struct platform_device *srsr_leaf)
 	struct calib_cache	*cache = NULL, *temp;
 	struct xrt_srsr_ioctl_calib req = { 0 };
 
-	ret = xrt_subdev_ioctl(srsr_leaf, XRT_SRSR_EP_NAME,
+	ret = xleaf_ioctl(srsr_leaf, XRT_SRSR_EP_NAME,
 		(void *)&ep_name);
 	if (ret) {
 		xrt_err(calib->pdev, "failed to get SRSR name %d", ret);
@@ -85,7 +85,7 @@ static int calib_srsr(struct calib *calib, struct platform_device *srsr_leaf)
 		if (!strncmp(ep_name, cache->ep_name, strlen(ep_name) + 1)) {
 			req.xsic_buf = cache->data;
 			req.xsic_size = cache->data_size;
-			ret = xrt_subdev_ioctl(srsr_leaf,
+			ret = xleaf_ioctl(srsr_leaf,
 				XRT_SRSR_FAST_CALIB, &req);
 			if (ret) {
 				xrt_err(calib->pdev, "Fast calib failed %d",
@@ -113,7 +113,7 @@ static int calib_srsr(struct calib *calib, struct platform_device *srsr_leaf)
 	}
 
 	req.xsic_buf = &cache->data;
-	ret = xrt_subdev_ioctl(srsr_leaf, XRT_SRSR_CALIB, &req);
+	ret = xleaf_ioctl(srsr_leaf, XRT_SRSR_CALIB, &req);
 	if (ret) {
 		xrt_err(calib->pdev, "Full calib failed %d", ret);
 		list_del(&cache->link);
@@ -164,11 +164,11 @@ static int xrt_calib_event_cb(struct platform_device *pdev,
 	switch (evt) {
 	case XRT_EVENT_POST_CREATION: {
 		if (esd->xevt_subdev_id == XRT_SUBDEV_SRSR) {
-			leaf = xrt_subdev_get_leaf_by_id(pdev,
+			leaf = xleaf_get_leaf_by_id(pdev,
 				XRT_SUBDEV_SRSR, esd->xevt_subdev_instance);
 			BUG_ON(!leaf);
 			ret = calib_srsr(calib, leaf);
-			xrt_subdev_put_leaf(pdev, leaf);
+			xleaf_put_leaf(pdev, leaf);
 			calib->result =
 				ret ? XRT_CALIB_FAILED : XRT_CALIB_SUCCEEDED;
 		} else if (esd->xevt_subdev_id == XRT_SUBDEV_UCS) {
@@ -190,7 +190,7 @@ static int xrt_calib_remove(struct platform_device *pdev)
 {
 	struct calib *calib = platform_get_drvdata(pdev);
 
-	xrt_subdev_remove_event_cb(pdev, calib->evt_hdl);
+	xleaf_remove_event_cb(pdev, calib->evt_hdl);
 	calib_cache_clean(calib);
 
 	if (calib->calib_base)
@@ -226,7 +226,7 @@ static int xrt_calib_probe(struct platform_device *pdev)
 		goto failed;
 	}
 
-	calib->evt_hdl = xrt_subdev_add_event_cb(pdev, xrt_calib_leaf_match,
+	calib->evt_hdl = xleaf_add_event_cb(pdev, xrt_calib_leaf_match,
 		NULL, xrt_calib_event_cb);
 
 	mutex_init(&calib->lock);

--- a/src/drivers/fpga/xrt/lib/subdevs/clkfreq.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/clkfreq.c
@@ -14,7 +14,7 @@
 #include <linux/device.h>
 #include <linux/io.h>
 #include "metadata.h"
-#include "subdev.h"
+#include "leaf.h"
 #include "parent.h"
 #include "subdev/clkfreq.h"
 

--- a/src/drivers/fpga/xrt/lib/subdevs/clock.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/clock.c
@@ -14,7 +14,7 @@
 #include <linux/device.h>
 #include <linux/io.h>
 #include "metadata.h"
-#include "subdev.h"
+#include "leaf.h"
 #include "parent.h"
 #include "subdev/clock.h"
 #include "subdev/clkfreq.h"
@@ -384,16 +384,16 @@ static int get_freq_counter(struct clock *clock, u32 *freq)
 		return err;
 	}
 
-	cnter_leaf = xrt_subdev_get_leaf_by_epname(pdev, cnter);
+	cnter_leaf = xleaf_get_leaf_by_epname(pdev, cnter);
 	if (!cnter_leaf) {
 		xrt_err(pdev, "can't find counter");
 		return -ENOENT;
 	}
 
-	err = xrt_subdev_ioctl(cnter_leaf, XRT_CLKFREQ_READ, freq);
+	err = xleaf_ioctl(cnter_leaf, XRT_CLKFREQ_READ, freq);
 	if (err)
 		xrt_err(pdev, "can't read counter");
-	xrt_subdev_put_leaf(clock->pdev, cnter_leaf);
+	xleaf_put_leaf(clock->pdev, cnter_leaf);
 
 	return err;
 }

--- a/src/drivers/fpga/xrt/lib/subdevs/cmc-bdinfo.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/cmc-bdinfo.c
@@ -6,7 +6,7 @@
  *	Cheng Zhen <maxz@xilinx.com>
  */
 
-#include "subdev.h"
+#include "leaf.h"
 #include "xrt-cmc-impl.h"
 #include "xmgmt-main.h"
 #include <linux/xrt/mailbox_proto.h>
@@ -169,7 +169,7 @@ static void cmc_copy_expect_bmc(struct xrt_cmc_bdinfo *cmc_bdi, void *expbmc)
 #define	NONE_BMC_VERSION	"0.0.0"
 	int ret = 0;
 	struct platform_device *pdev = cmc_bdi->pdev;
-	struct platform_device *mgmt_leaf = xrt_subdev_get_leaf_by_id(pdev,
+	struct platform_device *mgmt_leaf = xleaf_get_leaf_by_id(pdev,
 		XRT_SUBDEV_MGMT_MAIN, PLATFORM_DEVID_NONE);
 	struct xrt_mgmt_main_ioctl_get_axlf_section gs = { XMGMT_BLP, BMC, };
 	struct bmc *bmcsect;
@@ -181,7 +181,7 @@ static void cmc_copy_expect_bmc(struct xrt_cmc_bdinfo *cmc_bdi, void *expbmc)
 		return;
 	}
 
-	ret = xrt_subdev_ioctl(mgmt_leaf, XRT_MGMT_MAIN_GET_AXLF_SECTION, &gs);
+	ret = xleaf_ioctl(mgmt_leaf, XRT_MGMT_MAIN_GET_AXLF_SECTION, &gs);
 	if (ret == 0) {
 		bmcsect = (struct bmc *)gs.xmmigas_section;
 		memcpy(expbmc, bmcsect->m_version, sizeof(bmcsect->m_version));
@@ -192,7 +192,7 @@ static void cmc_copy_expect_bmc(struct xrt_cmc_bdinfo *cmc_bdi, void *expbmc)
 		 */
 		cmc_copy_board_info_by_key(cmc_bdi, BDINFO_BMC_VER, expbmc);
 	}
-	(void) xrt_subdev_put_leaf(pdev, mgmt_leaf);
+	(void) xleaf_put_leaf(pdev, mgmt_leaf);
 }
 
 int cmc_bdinfo_read(struct platform_device *pdev, struct xcl_board_info *bdinfo)

--- a/src/drivers/fpga/xrt/lib/subdevs/cmc-ctrl.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/cmc-ctrl.c
@@ -9,7 +9,7 @@
 #include <linux/delay.h>
 #include <linux/string.h>
 #include <linux/vmalloc.h>
-#include "subdev.h"
+#include "leaf.h"
 #include "xmgmt-main.h"
 #include "xrt-cmc-impl.h"
 
@@ -174,7 +174,7 @@ static int cmc_fetch_firmware(struct xrt_cmc_ctrl *cmc_ctrl)
 {
 	int ret = 0;
 	struct platform_device *pdev = cmc_ctrl->pdev;
-	struct platform_device *mgmt_leaf = xrt_subdev_get_leaf_by_id(pdev,
+	struct platform_device *mgmt_leaf = xleaf_get_leaf_by_id(pdev,
 		XRT_SUBDEV_MGMT_MAIN, PLATFORM_DEVID_NONE);
 	struct xrt_mgmt_main_ioctl_get_axlf_section gs = {
 		XMGMT_BLP, FIRMWARE,
@@ -183,7 +183,7 @@ static int cmc_fetch_firmware(struct xrt_cmc_ctrl *cmc_ctrl)
 	if (mgmt_leaf == NULL)
 		return -ENOENT;
 
-	ret = xrt_subdev_ioctl(mgmt_leaf, XRT_MGMT_MAIN_GET_AXLF_SECTION, &gs);
+	ret = xleaf_ioctl(mgmt_leaf, XRT_MGMT_MAIN_GET_AXLF_SECTION, &gs);
 	if (ret == 0) {
 		cmc_ctrl->firmware = vmalloc(gs.xmmigas_section_size);
 		if (cmc_ctrl->firmware == NULL) {
@@ -196,7 +196,7 @@ static int cmc_fetch_firmware(struct xrt_cmc_ctrl *cmc_ctrl)
 	} else {
 		xrt_err(pdev, "failed to fetch firmware: %d", ret);
 	}
-	(void) xrt_subdev_put_leaf(pdev, mgmt_leaf);
+	(void) xleaf_put_leaf(pdev, mgmt_leaf);
 
 	return ret;
 }
@@ -229,7 +229,7 @@ void cmc_ctrl_remove(struct platform_device *pdev)
 		return;
 
 	if (cmc_ctrl->evt_hdl)
-		(void) xrt_subdev_remove_event_cb(pdev, cmc_ctrl->evt_hdl);
+		(void) xleaf_remove_event_cb(pdev, cmc_ctrl->evt_hdl);
 	(void) sysfs_remove_group(&DEV(cmc_ctrl->pdev)->kobj,
 		&cmc_ctrl_attr_group);
 	(void) cmc_ulp_access(cmc_ctrl, false);
@@ -309,7 +309,7 @@ int cmc_ctrl_probe(struct platform_device *pdev,
 	if (ret)
 		xrt_err(pdev, "failed to create sysfs nodes: %d", ret);
 
-	cmc_ctrl->evt_hdl = xrt_subdev_add_event_cb(pdev,
+	cmc_ctrl->evt_hdl = xleaf_add_event_cb(pdev,
 		cmc_ctrl_leaf_match, NULL, cmc_ctrl_event_cb);
 
 	*hdl = cmc_ctrl;

--- a/src/drivers/fpga/xrt/lib/subdevs/cmc-mailbox.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/cmc-mailbox.c
@@ -8,7 +8,7 @@
 
 #include <linux/mutex.h>
 #include <linux/delay.h>
-#include "subdev.h"
+#include "leaf.h"
 #include "xrt-cmc-impl.h"
 
 /* We have a 4k buffer for cmc mailbox */

--- a/src/drivers/fpga/xrt/lib/subdevs/cmc-sc.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/cmc-sc.c
@@ -7,7 +7,7 @@
  */
 
 #include <linux/uaccess.h>
-#include "subdev.h"
+#include "leaf.h"
 #include "xrt-cmc-impl.h"
 
 #define	CMC_CORE_SUPPORT_NOTUPGRADABLE	0x0c010004
@@ -251,7 +251,7 @@ ssize_t cmc_update_sc_firmware(struct file *file,
  */
 int cmc_sc_open(struct inode *inode, struct file *file)
 {
-	struct platform_device *pdev = xrt_devnode_open_excl(inode);
+	struct platform_device *pdev = xleaf_devnode_open_excl(inode);
 
 	file->private_data = cmc_pdev2sc(pdev);
 	return 0;
@@ -265,7 +265,7 @@ int cmc_sc_close(struct inode *inode, struct file *file)
 		return -EINVAL;
 
 	file->private_data = NULL;
-	xrt_devnode_close(inode);
+	xleaf_devnode_close(inode);
 	return 0;
 }
 

--- a/src/drivers/fpga/xrt/lib/subdevs/cmc-sensors.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/cmc-sensors.c
@@ -333,7 +333,7 @@ void cmc_sensor_remove(struct platform_device *pdev)
 
 	BUG_ON(cmc_sensor == NULL);
 	if (cmc_sensor->hwmon_dev)
-		xrt_subdev_unregister_hwmon(pdev, cmc_sensor->hwmon_dev);
+		xleaf_unregister_hwmon(pdev, cmc_sensor->hwmon_dev);
 	kfree(cmc_sensor->name);
 }
 
@@ -342,14 +342,14 @@ static const char *cmc_get_vbnv(struct xrt_cmc_sensor *cmc_sensor)
 	int ret;
 	const char *vbnv;
 	struct platform_device *mgmt_leaf =
-		xrt_subdev_get_leaf_by_id(cmc_sensor->pdev,
+		xleaf_get_leaf_by_id(cmc_sensor->pdev,
 		XRT_SUBDEV_MGMT_MAIN, PLATFORM_DEVID_NONE);
 
 	if (mgmt_leaf == NULL)
 		return NULL;
 
-	ret = xrt_subdev_ioctl(mgmt_leaf, XRT_MGMT_MAIN_GET_VBNV, &vbnv);
-	(void) xrt_subdev_put_leaf(cmc_sensor->pdev, mgmt_leaf);
+	ret = xleaf_ioctl(mgmt_leaf, XRT_MGMT_MAIN_GET_VBNV, &vbnv);
+	(void) xleaf_put_leaf(cmc_sensor->pdev, mgmt_leaf);
 	if (ret)
 		return NULL;
 	return vbnv;
@@ -375,7 +375,7 @@ int cmc_sensor_probe(struct platform_device *pdev,
 	 * Make a parent call to ask root to register. If we register using
 	 * platform device, we'll be treated as ISA device, not PCI device.
 	 */
-	cmc_sensor->hwmon_dev = xrt_subdev_register_hwmon(pdev,
+	cmc_sensor->hwmon_dev = xleaf_register_hwmon(pdev,
 		vbnv, cmc_sensor, hwmon_cmc_attrgroups);
 	if (cmc_sensor->hwmon_dev == NULL)
 		xrt_err(pdev, "failed to create HWMON device");

--- a/src/drivers/fpga/xrt/lib/subdevs/cmc.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/cmc.c
@@ -9,7 +9,7 @@
  */
 
 #include "metadata.h"
-#include "subdev.h"
+#include "leaf.h"
 #include "xrt-cmc-impl.h"
 #include "subdev/cmc.h"
 #include <linux/xrt/mailbox_proto.h>

--- a/src/drivers/fpga/xrt/lib/subdevs/gpio.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/gpio.c
@@ -14,7 +14,7 @@
 #include <linux/device.h>
 #include <linux/io.h>
 #include "metadata.h"
-#include "subdev.h"
+#include "leaf.h"
 #include "parent.h"
 #include "subdev/gpio.h"
 

--- a/src/drivers/fpga/xrt/lib/subdevs/icap.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/icap.c
@@ -14,7 +14,7 @@
 #include <linux/device.h>
 #include <linux/io.h>
 #include "metadata.h"
-#include "subdev.h"
+#include "leaf.h"
 #include "parent.h"
 #include "subdev/icap.h"
 #include "xclbin-helper.h"

--- a/src/drivers/fpga/xrt/lib/subdevs/mailbox.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/mailbox.c
@@ -175,7 +175,7 @@
 #include <linux/crc32c.h>
 #include <linux/xrt/mailbox_transport.h>
 #include "metadata.h"
-#include "subdev.h"
+#include "leaf.h"
 #include "subdev/mailbox.h"
 #include "xmgmt-main.h"
 
@@ -1590,7 +1590,7 @@ static int mailbox_open(struct inode *inode, struct file *file)
 	 * Only allow one open from daemon. Mailbox msg can only be polled
 	 * by one daemon.
 	 */
-	struct platform_device *pdev = xrt_devnode_open_excl(inode);
+	struct platform_device *pdev = xleaf_devnode_open_excl(inode);
 	struct mailbox *mbx = NULL;
 
 	if (!pdev)
@@ -1622,7 +1622,7 @@ static int mailbox_close(struct inode *inode, struct file *file)
 	mutex_lock(&mbx->mbx_lock);
 	mbx->mbx_opened--;
 	mutex_unlock(&mbx->mbx_lock);
-	xrt_devnode_close(inode);
+	xleaf_devnode_close(inode);
 	return 0;
 }
 

--- a/src/drivers/fpga/xrt/lib/subdevs/qspi.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/qspi.c
@@ -11,7 +11,7 @@
 #include <linux/delay.h>
 #include <linux/uaccess.h>
 #include "metadata.h"
-#include "subdev.h"
+#include "leaf.h"
 #include "subdev/flash.h"
 
 #define	XRT_QSPI "xrt_qspi"
@@ -1077,7 +1077,7 @@ qspi_llseek(struct file *filp, loff_t off, int whence)
 static int qspi_open(struct inode *inode, struct file *file)
 {
 	struct xrt_qspi *flash;
-	struct platform_device *pdev = xrt_devnode_open_excl(inode);
+	struct platform_device *pdev = xleaf_devnode_open_excl(inode);
 
 	if (!pdev)
 		return -EBUSY;
@@ -1095,7 +1095,7 @@ static int qspi_close(struct inode *inode, struct file *file)
 		return -EINVAL;
 
 	file->private_data = NULL;
-	xrt_devnode_close(inode);
+	xleaf_devnode_close(inode);
 	return 0;
 }
 

--- a/src/drivers/fpga/xrt/lib/subdevs/srsr.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/srsr.c
@@ -14,7 +14,7 @@
 #include <linux/device.h>
 #include <linux/io.h>
 #include "metadata.h"
-#include "subdev.h"
+#include "leaf.h"
 #include "parent.h"
 #include "subdev/ddr-srsr.h"
 

--- a/src/drivers/fpga/xrt/lib/subdevs/ucs.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/ucs.c
@@ -14,7 +14,7 @@
 #include <linux/device.h>
 #include <linux/io.h>
 #include "metadata.h"
-#include "subdev.h"
+#include "leaf.h"
 #include "parent.h"
 #include "subdev/ucs.h"
 #include "subdev/clock.h"
@@ -84,11 +84,11 @@ static int xrt_ucs_event_cb(struct platform_device *pdev,
 		return XRT_EVENT_CB_CONTINUE;
 	}
 
-	leaf = xrt_subdev_get_leaf_by_id(pdev,
+	leaf = xleaf_get_leaf_by_id(pdev,
 		XRT_SUBDEV_CLOCK, esd->xevt_subdev_instance);
 	BUG_ON(!leaf);
-	xrt_subdev_ioctl(leaf, XRT_CLOCK_VERIFY, NULL);
-	xrt_subdev_put_leaf(pdev, leaf);
+	xleaf_ioctl(leaf, XRT_CLOCK_VERIFY, NULL);
+	xleaf_put_leaf(pdev, leaf);
 
 	return XRT_EVENT_CB_CONTINUE;
 }
@@ -157,7 +157,7 @@ static int ucs_remove(struct platform_device *pdev)
 		return -EINVAL;
 	}
 
-	xrt_subdev_remove_event_cb(pdev, ucs->evt_hdl);
+	xleaf_remove_event_cb(pdev, ucs->evt_hdl);
 	if (ucs->ucs_base)
 		iounmap(ucs->ucs_base);
 
@@ -191,7 +191,7 @@ static int ucs_probe(struct platform_device *pdev)
 		goto failed;
 	}
 	ucs_enable(ucs);
-	ucs->evt_hdl = xrt_subdev_add_event_cb(pdev, xrt_ucs_leaf_match,
+	ucs->evt_hdl = xleaf_add_event_cb(pdev, xrt_ucs_leaf_match,
 		NULL, xrt_ucs_event_cb);
 
 	return 0;

--- a/src/drivers/fpga/xrt/lib/subdevs/vsec-golden.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/vsec-golden.c
@@ -10,7 +10,7 @@
 
 #include <linux/platform_device.h>
 #include "metadata.h"
-#include "subdev.h"
+#include "leaf.h"
 #include "subdev/gpio.h"
 
 #define XRT_VSEC_GOLDEN "xrt_vsec_golden"
@@ -59,7 +59,7 @@ static int xrt_vsec_get_golden_ver(struct xrt_vsec *vsec)
 	struct xrt_gpio_ioctl_rw gpio_arg = { 0 };
 	int err, ver;
 
-	gpio_leaf = xrt_subdev_get_leaf_by_epname(pdev, NODE_GOLDEN_VER);
+	gpio_leaf = xleaf_get_leaf_by_epname(pdev, NODE_GOLDEN_VER);
 	if (!gpio_leaf) {
 		xrt_err(pdev, "can not get %s", NODE_GOLDEN_VER);
 		return -EINVAL;
@@ -69,8 +69,8 @@ static int xrt_vsec_get_golden_ver(struct xrt_vsec *vsec)
 	gpio_arg.xgir_buf = &ver;
 	gpio_arg.xgir_len = sizeof(ver);
 	gpio_arg.xgir_offset = 0;
-	err = xrt_subdev_ioctl(gpio_leaf, XRT_GPIO_READ, &gpio_arg);
-	(void) xrt_subdev_put_leaf(pdev, gpio_leaf);
+	err = xleaf_ioctl(gpio_leaf, XRT_GPIO_READ, &gpio_arg);
+	(void) xleaf_put_leaf(pdev, gpio_leaf);
 	if (err) {
 		xrt_err(pdev, "can't get golden image version: %d", err);
 		return err;
@@ -174,7 +174,7 @@ static int xrt_vsec_probe(struct platform_device *pdev)
 		return -ENOMEM;
 
 	vsec->pdev = pdev;
-	xrt_subdev_get_parent_id(pdev, &vsec->vendor, &vsec->device,
+	xleaf_get_parent_id(pdev, &vsec->vendor, &vsec->device,
 		NULL, NULL);
 	platform_set_drvdata(pdev, vsec);
 
@@ -183,7 +183,7 @@ static int xrt_vsec_probe(struct platform_device *pdev)
 		xrt_err(pdev, "create metadata failed, ret %d", ret);
 		goto failed;
 	}
-	ret = xrt_subdev_create_partition(pdev, vsec->metadata);
+	ret = xleaf_create_partition(pdev, vsec->metadata);
 	if (ret < 0)
 		xrt_err(pdev, "create partition failed, ret %d", ret);
 	else

--- a/src/drivers/fpga/xrt/lib/subdevs/vsec.c
+++ b/src/drivers/fpga/xrt/lib/subdevs/vsec.c
@@ -10,7 +10,7 @@
 
 #include <linux/platform_device.h>
 #include "metadata.h"
-#include "subdev.h"
+#include "leaf.h"
 
 #define XRT_VSEC "xrt_vsec"
 
@@ -230,7 +230,7 @@ static int xrt_vsec_mapio(struct xrt_vsec *vsec)
 	xrt_info(vsec->pdev, "Map vsec at bar %d, offset 0x%llx",
 		be32_to_cpu(*bar), be64_to_cpu(*bar_off));
 
-	xrt_subdev_get_barres(vsec->pdev, &res, be32_to_cpu(*bar));
+	xleaf_get_barres(vsec->pdev, &res, be32_to_cpu(*bar));
 	if (!res) {
 		xrt_err(vsec->pdev, "failed to get bar addr");
 		return -EINVAL;
@@ -292,7 +292,7 @@ static int xrt_vsec_probe(struct platform_device *pdev)
 		xrt_err(pdev, "create metadata failed, ret %d", ret);
 		goto failed;
 	}
-	ret = xrt_subdev_create_partition(pdev, vsec->metadata);
+	ret = xleaf_create_partition(pdev, vsec->metadata);
 	if (ret < 0)
 		xrt_err(pdev, "create partition failed, ret %d", ret);
 	else

--- a/src/drivers/fpga/xrt/lib/subdevs/xrt-cmc-impl.h
+++ b/src/drivers/fpga/xrt/lib/subdevs/xrt-cmc-impl.h
@@ -10,7 +10,7 @@
 #define	_XRT_CMC_IMPL_H_
 
 #include "linux/delay.h"
-#include "subdev.h"
+#include "leaf.h"
 #include <linux/xrt/mailbox_proto.h>
 
 #define	CMC_MAX_RETRY		150 /* Retry is set to 15s */

--- a/src/drivers/fpga/xrt/mgmt/fmgr-drv.c
+++ b/src/drivers/fpga/xrt/mgmt/fmgr-drv.c
@@ -16,7 +16,7 @@
 #include <linux/vmalloc.h>
 
 #include "xclbin-helper.h"
-#include "subdev.h"
+#include "leaf.h"
 #include "fmgr.h"
 #include "subdev/axigate.h"
 #include "subdev/icap.h"
@@ -54,7 +54,7 @@ static int xmgmt_download_bitstream(struct platform_device *pdev,
 		xrt_err(pdev, "invalid bitstream header");
 		goto done;
 	}
-	icap_leaf = xrt_subdev_get_leaf_by_id(pdev, XRT_SUBDEV_ICAP,
+	icap_leaf = xleaf_get_leaf_by_id(pdev, XRT_SUBDEV_ICAP,
 		PLATFORM_DEVID_NONE);
 	if (!icap_leaf) {
 		ret = -ENODEV;
@@ -63,13 +63,13 @@ static int xmgmt_download_bitstream(struct platform_device *pdev,
 	}
 	arg.xiiw_bit_data = bitstream + bit_header.HeaderLength;
 	arg.xiiw_data_len = bit_header.BitstreamLength;
-	ret = xrt_subdev_ioctl(icap_leaf, XRT_ICAP_WRITE, &arg);
+	ret = xleaf_ioctl(icap_leaf, XRT_ICAP_WRITE, &arg);
 	if (ret)
 		xrt_err(pdev, "write bitstream failed, ret = %d", ret);
 
 done:
 	if (icap_leaf)
-		xrt_subdev_put_leaf(pdev, icap_leaf);
+		xleaf_put_leaf(pdev, icap_leaf);
 	vfree(bitstream);
 
 	return ret;

--- a/src/drivers/fpga/xrt/mgmt/main-impl.h
+++ b/src/drivers/fpga/xrt/mgmt/main-impl.h
@@ -10,13 +10,10 @@
 #ifndef	_XMGMT_MAIN_IMPL_H_
 #define	_XMGMT_MAIN_IMPL_H_
 
-#include "subdev.h"
+#include <linux/platform_device.h>
 #include "xmgmt-main.h"
 
 struct fpga_manager;
-extern struct platform_driver xmgmt_main_driver;
-extern struct xrt_subdev_endpoints xrt_mgmt_main_endpoints[];
-
 extern int xmgmt_process_xclbin(struct platform_device *pdev,
 	struct fpga_manager *fmgr, const struct axlf *xclbin, enum provider_kind kind);
 extern void xmgmt_region_cleanup_all(struct platform_device *pdev);
@@ -36,5 +33,8 @@ extern void *xmgmt_pdev2mailbox(struct platform_device *pdev);
 extern void *xmgmt_mailbox_probe(struct platform_device *pdev);
 extern void xmgmt_mailbox_remove(void *handle);
 extern void xmgmt_peer_notify_state(void *handle, bool online);
+
+extern int xmgmt_main_register_leaf(void);
+extern void xmgmt_main_unregister_leaf(void);
 
 #endif	/* _XMGMT_MAIN_IMPL_H_ */

--- a/src/drivers/fpga/xrt/mgmt/main-mailbox.c
+++ b/src/drivers/fpga/xrt/mgmt/main-mailbox.c
@@ -85,7 +85,7 @@ static void xmgmt_mailbox_post(struct xmgmt_mailbox *xmbx,
 		XMGMT_MAILBOX_PRT_RESP(xmbx, &post);
 	}
 
-	rc = xrt_subdev_ioctl(xmbx->mailbox, XRT_MAILBOX_POST, &post);
+	rc = xleaf_ioctl(xmbx->mailbox, XRT_MAILBOX_POST, &post);
 	if (rc)
 		xrt_err(xmbx->pdev, "failed to post msg: %d", rc);
 }
@@ -378,13 +378,13 @@ static void xmgmt_mailbox_resp_sensor(struct xmgmt_mailbox *xmbx,
 {
 	struct platform_device *pdev = xmbx->pdev;
 	struct xcl_sensor sensors = { 0 };
-	struct platform_device *cmcpdev = xrt_subdev_get_leaf_by_id(pdev,
+	struct platform_device *cmcpdev = xleaf_get_leaf_by_id(pdev,
 		XRT_SUBDEV_CMC, PLATFORM_DEVID_NONE);
 	int rc;
 
 	if (cmcpdev) {
-		rc = xrt_subdev_ioctl(cmcpdev, XRT_CMC_READ_SENSORS, &sensors);
-		(void) xrt_subdev_put_leaf(pdev, cmcpdev);
+		rc = xleaf_ioctl(cmcpdev, XRT_CMC_READ_SENSORS, &sensors);
+		(void) xleaf_put_leaf(pdev, cmcpdev);
 		if (rc)
 			xrt_err(pdev, "can't read sensors: %d", rc);
 	}
@@ -401,7 +401,7 @@ static int xmgmt_mailbox_get_freq(struct xmgmt_mailbox *xmbx,
 		xrt_clock_type2epname(type) ?
 		xrt_clock_type2epname(type) : "UNKNOWN";
 	struct platform_device *clkpdev =
-		xrt_subdev_get_leaf_by_epname(pdev, clkname);
+		xleaf_get_leaf_by_epname(pdev, clkname);
 	int rc;
 	struct xrt_clock_ioctl_get getfreq = { 0 };
 
@@ -410,8 +410,8 @@ static int xmgmt_mailbox_get_freq(struct xmgmt_mailbox *xmbx,
 		return -ENOENT;
 	}
 
-	rc = xrt_subdev_ioctl(clkpdev, XRT_CLOCK_GET, &getfreq);
-	(void) xrt_subdev_put_leaf(pdev, clkpdev);
+	rc = xleaf_ioctl(clkpdev, XRT_CLOCK_GET, &getfreq);
+	(void) xleaf_put_leaf(pdev, clkpdev);
 	if (rc) {
 		xrt_err(pdev, "can't get %s clock frequency: %d", clkname, rc);
 		return rc;
@@ -427,7 +427,7 @@ static int xmgmt_mailbox_get_freq(struct xmgmt_mailbox *xmbx,
 static int xmgmt_mailbox_get_icap_idcode(struct xmgmt_mailbox *xmbx, u64 *id)
 {
 	struct platform_device *pdev = xmbx->pdev;
-	struct platform_device *icappdev = xrt_subdev_get_leaf_by_id(pdev,
+	struct platform_device *icappdev = xleaf_get_leaf_by_id(pdev,
 		XRT_SUBDEV_ICAP, PLATFORM_DEVID_NONE);
 	int rc;
 
@@ -436,8 +436,8 @@ static int xmgmt_mailbox_get_icap_idcode(struct xmgmt_mailbox *xmbx, u64 *id)
 		return -ENOENT;
 	}
 
-	rc = xrt_subdev_ioctl(icappdev, XRT_ICAP_IDCODE, id);
-	(void) xrt_subdev_put_leaf(pdev, icappdev);
+	rc = xleaf_ioctl(icappdev, XRT_ICAP_IDCODE, id);
+	(void) xleaf_put_leaf(pdev, icappdev);
 	if (rc)
 		xrt_err(pdev, "can't get icap idcode: %d", rc);
 	return rc;
@@ -446,7 +446,7 @@ static int xmgmt_mailbox_get_icap_idcode(struct xmgmt_mailbox *xmbx, u64 *id)
 static int xmgmt_mailbox_get_mig_calib(struct xmgmt_mailbox *xmbx, u64 *calib)
 {
 	struct platform_device *pdev = xmbx->pdev;
-	struct platform_device *calibpdev = xrt_subdev_get_leaf_by_id(pdev,
+	struct platform_device *calibpdev = xleaf_get_leaf_by_id(pdev,
 		XRT_SUBDEV_CALIB, PLATFORM_DEVID_NONE);
 	int rc;
 	enum xrt_calib_results res;
@@ -456,8 +456,8 @@ static int xmgmt_mailbox_get_mig_calib(struct xmgmt_mailbox *xmbx, u64 *calib)
 		return -ENOENT;
 	}
 
-	rc = xrt_subdev_ioctl(calibpdev, XRT_CALIB_RESULT, &res);
-	(void) xrt_subdev_put_leaf(pdev, calibpdev);
+	rc = xleaf_ioctl(calibpdev, XRT_CALIB_RESULT, &res);
+	(void) xleaf_put_leaf(pdev, calibpdev);
 	if (rc) {
 		xrt_err(pdev, "can't get mig calibration result: %d", rc);
 	} else {
@@ -501,11 +501,11 @@ static void xmgmt_mailbox_resp_bdinfo(struct xmgmt_mailbox *xmbx,
 	if (info == NULL)
 		return;
 
-	cmcpdev = xrt_subdev_get_leaf_by_id(pdev,
+	cmcpdev = xleaf_get_leaf_by_id(pdev,
 		XRT_SUBDEV_CMC, PLATFORM_DEVID_NONE);
 	if (cmcpdev) {
-		rc = xrt_subdev_ioctl(cmcpdev, XRT_CMC_READ_BOARD_INFO, info);
-		(void) xrt_subdev_put_leaf(pdev, cmcpdev);
+		rc = xleaf_ioctl(cmcpdev, XRT_CMC_READ_BOARD_INFO, info);
+		(void) xleaf_put_leaf(pdev, cmcpdev);
 		if (rc)
 			xrt_err(pdev, "can't read board info: %d", rc);
 	}
@@ -697,7 +697,7 @@ static void xmgmt_mailbox_reg_listener(struct xmgmt_mailbox *xmbx)
 	BUG_ON(!mutex_is_locked(&xmbx->lock));
 	if (!xmbx->mailbox)
 		return;
-	(void) xrt_subdev_ioctl(xmbx->mailbox, XRT_MAILBOX_LISTEN, &listen);
+	(void) xleaf_ioctl(xmbx->mailbox, XRT_MAILBOX_LISTEN, &listen);
 }
 
 static void xmgmt_mailbox_unreg_listener(struct xmgmt_mailbox *xmbx)
@@ -706,7 +706,7 @@ static void xmgmt_mailbox_unreg_listener(struct xmgmt_mailbox *xmbx)
 
 	BUG_ON(!mutex_is_locked(&xmbx->lock));
 	BUG_ON(!xmbx->mailbox);
-	(void) xrt_subdev_ioctl(xmbx->mailbox, XRT_MAILBOX_LISTEN, &listen);
+	(void) xleaf_ioctl(xmbx->mailbox, XRT_MAILBOX_LISTEN, &listen);
 }
 
 static bool xmgmt_mailbox_leaf_match(enum xrt_subdev_id id,
@@ -726,7 +726,7 @@ static int xmgmt_mailbox_event_cb(struct platform_device *pdev,
 		BUG_ON(esd->xevt_subdev_id != XRT_SUBDEV_MAILBOX);
 		BUG_ON(xmbx->mailbox);
 		mutex_lock(&xmbx->lock);
-		xmbx->mailbox = xrt_subdev_get_leaf_by_id(pdev,
+		xmbx->mailbox = xleaf_get_leaf_by_id(pdev,
 			XRT_SUBDEV_MAILBOX, PLATFORM_DEVID_NONE);
 		xmgmt_mailbox_reg_listener(xmbx);
 		mutex_unlock(&xmbx->lock);
@@ -736,7 +736,7 @@ static int xmgmt_mailbox_event_cb(struct platform_device *pdev,
 		BUG_ON(!xmbx->mailbox);
 		mutex_lock(&xmbx->lock);
 		xmgmt_mailbox_unreg_listener(xmbx);
-		(void) xrt_subdev_put_leaf(pdev, xmbx->mailbox);
+		(void) xleaf_put_leaf(pdev, xmbx->mailbox);
 		xmbx->mailbox = NULL;
 		mutex_unlock(&xmbx->lock);
 		break;
@@ -818,7 +818,7 @@ static int xmgmt_mailbox_get_test_msg(struct xmgmt_mailbox *xmbx, bool sw_ch,
 		 * either notification or response. here is the only exception
 		 * for debugging purpose.
 		 */
-		rc = xrt_subdev_ioctl(xmbx->mailbox,
+		rc = xleaf_ioctl(xmbx->mailbox,
 			XRT_MAILBOX_REQUEST, &leaf_req);
 	} else {
 		rc = -ENODEV;
@@ -891,7 +891,7 @@ void *xmgmt_mailbox_probe(struct platform_device *pdev)
 	xmbx->pdev = pdev;
 	mutex_init(&xmbx->lock);
 
-	xmbx->evt_hdl = xrt_subdev_add_event_cb(pdev,
+	xmbx->evt_hdl = xleaf_add_event_cb(pdev,
 		xmgmt_mailbox_leaf_match, NULL, xmgmt_mailbox_event_cb);
 	(void) sysfs_create_group(&DEV(pdev)->kobj, &xmgmt_mailbox_attrgroup);
 	return xmbx;
@@ -904,9 +904,9 @@ void xmgmt_mailbox_remove(void *handle)
 
 	(void) sysfs_remove_group(&DEV(pdev)->kobj, &xmgmt_mailbox_attrgroup);
 	if (xmbx->evt_hdl)
-		(void) xrt_subdev_remove_event_cb(pdev, xmbx->evt_hdl);
+		(void) xleaf_remove_event_cb(pdev, xmbx->evt_hdl);
 	if (xmbx->mailbox)
-		(void) xrt_subdev_put_leaf(pdev, xmbx->mailbox);
+		(void) xleaf_put_leaf(pdev, xmbx->mailbox);
 	if (xmbx->test_msg)
 		vfree(xmbx->test_msg);
 }


### PR DESCRIPTION
@sonals , let me know if this is what you're looking for?

Notes:
- xrt-lib.ko - infra and leaves
- xmgmt.ko - pf-specific root and main leaf
- pf-specific root should include root.h to get access to APIs for root drivers prefixed by "xroot_"
- all leaves including main should include leaf.h to get access to APIs for leaf drivers prefixed by "xleaf_"