### PR TITLE
compiling warning with latest linux kernel

### DIFF
--- a/src/drivers/fpga/xrt/mgmt/main-mailbox.c
+++ b/src/drivers/fpga/xrt/mgmt/main-mailbox.c
@@ -878,13 +878,19 @@ void *xmgmt_mailbox_probe(struct platform_device *pdev)
 {
 	struct xmgmt_mailbox *xmbx =
 		devm_kzalloc(DEV(pdev), sizeof(*xmbx), GFP_KERNEL);
+	int ret;
 
 	if (!xmbx)
 		return NULL;
 	xmbx->pdev = pdev;
 	mutex_init(&xmbx->lock);
 
-	(void) sysfs_create_group(&DEV(pdev)->kobj, &xmgmt_mailbox_attrgroup);
+	ret = sysfs_create_group(&DEV(pdev)->kobj, &xmgmt_mailbox_attrgroup);
+	if (ret) {
+		xrt_err(pdev, "create sysfs group failed, ret %d", ret);
+		return NULL;
+	}
+
 	return xmbx;
 }
 

--- a/src/drivers/fpga/xrt/mgmt/root.c
+++ b/src/drivers/fpga/xrt/mgmt/root.c
@@ -158,7 +158,7 @@ static void xmgmt_root_hot_reset(struct pci_dev *pdev)
 	struct pci_bus *bus;
 	u8 pci_bctl;
 	u16 pci_cmd, devctl;
-	int i;
+	int i, ret;
 
 	xmgmt_info(xm, "hot reset start");
 
@@ -195,7 +195,9 @@ static void xmgmt_root_hot_reset(struct pci_dev *pdev)
 	pcie_capability_write_word(bus->self, PCI_EXP_DEVCTL, devctl);
 	pci_write_config_word(bus->self, PCI_COMMAND, pci_cmd);
 
-	pci_enable_device(pdev);
+	ret = pci_enable_device(pdev);
+	if (ret)
+		xmgmt_err(xm, "failed to enable device, ret %d", ret);
 
 	for (i = 0; i < 300; i++) {
 		pci_read_config_word(pdev, PCI_COMMAND, &pci_cmd);


### PR DESCRIPTION
 CC [M]  drivers/fpga/xrt/mgmt/main.o
  CC [M]  drivers/fpga/xrt/mgmt/fmgr-drv.o
drivers/fpga/xrt/mgmt/root.c: In function ‘xmgmt_root_hot_reset’:
drivers/fpga/xrt/mgmt/root.c:198:2: warning: ignoring return value of ‘pci_enable_device’, declared with attribute warn_unused_result [-Wunused-result]
  pci_enable_device(pdev);
  ^
  CC [M]  drivers/fpga/xrt/mgmt/main-region.o
  CC [M]  drivers/fpga/xrt/mgmt/main-mailbox.o
drivers/fpga/xrt/mgmt/main-mailbox.c: In function ‘xmgmt_mailbox_probe’:
drivers/fpga/xrt/mgmt/main-mailbox.c:887:2: warning: ignoring return value of ‘sysfs_create_group’, declared with attribute warn_unused_result [-Wunused-result]
  (void) sysfs_create_group(&DEV(pdev)->kobj, &xmgmt_mailbox_attrgroup);
  ^
